### PR TITLE
[Feat] 진행 상태에 따른 멤버의 미션 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/umc/workbook/controller/MissionController.java
+++ b/src/main/java/com/umc/workbook/controller/MissionController.java
@@ -8,6 +8,7 @@ import com.umc.workbook.dto.mission.MissionResponse;
 import com.umc.workbook.service.MissionService.MissionCommandService;
 import com.umc.workbook.service.MissionService.MissionQueryService;
 import com.umc.workbook.validation.annotation.CheckPage;
+import com.umc.workbook.validation.annotation.ExistMember;
 import com.umc.workbook.validation.annotation.ExistStore;
 import com.umc.workbook.validation.annotation.ValidMissionStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -91,7 +92,7 @@ public class MissionController {
     }
 
     // 특정 가게의 미션 목록 조회
-    @GetMapping
+    @GetMapping("/store")
     @Operation(summary = "특정 가게의 미션 목록 조회 API", description = "가게의 모든 미션 목록을 조회하는 API이며, 페이징을 포함합니다. query String 으로 page 번호를 주세요")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
@@ -100,11 +101,34 @@ public class MissionController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
     })
     @Parameters({
-            @Parameter(name = "storeId", description = "가게의 아이디, path variable 입니다."),
+            @Parameter(name = "storeId", description = "가게의 아이디, query parameter 입니다."),
             @Parameter(name = "page", description = "페이지 번호, query parameter 입니다.")
     })
-    ApiResponse<MissionResponse.StoreMissionPreViewListDTO> getStoreMissionPage (@RequestParam(name = "storeId") @ExistStore Long storeId, @CheckPage Integer page){
+    ApiResponse<MissionResponse.StoreMissionPreViewListDTO> getStoreMissionPage (@RequestParam(name = "storeId") @ExistStore Long storeId,
+                                                                                 @CheckPage Integer page){
         MissionResponse.StoreMissionPreViewListDTO response = missionQueryService.getStoreMissionPage(storeId, page);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    // 멤버의 진행중 or 진행완료 미션 목록 조회
+    @GetMapping("/member")
+    @Operation(summary = "멤버의 진행중 or 진행완료 미션 목록 조회 API", description = "status에 따른 멤버의 모든 미션 목록을 조회하는 API이며, 페이징을 포함합니다. query String 으로 page 번호를 주세요")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "memberId", description = "멤버의 아이디, query parameter 입니다."),
+            @Parameter(name = "status", description = "미션 상태, 진행중일 경우 challenging, 진행완료일 경우 complete 입니다."),
+            @Parameter(name = "page", description = "페이지 번호, query parameter 입니다.")
+    })
+    ApiResponse<MissionResponse.MemberMissionPreViewListDTO> getMemberChallengeMissionPage (@RequestParam(name = "memberId") @ExistMember Long memberId,
+                                                                                            @RequestParam(name = "status") String status,
+                                                                                            @CheckPage Integer page){
+        MissionResponse.MemberMissionPreViewListDTO response = missionQueryService.getMemberMissionPage(memberId, status, page);
 
         return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/com/umc/workbook/converter/MissionConverter.java
+++ b/src/main/java/com/umc/workbook/converter/MissionConverter.java
@@ -52,7 +52,7 @@ public class MissionConverter {
     public static MissionResponse.StoreMissionPreViewListDTO toStoreMissionPreViewListDTO(Page<Mission> storeMissionPage, String storeName){
         // Mission 리스트를 StoreMissionPreviewDTO로 변환
         List<MissionResponse.StoreMissionPreviewDTO> storeMissionList = storeMissionPage.stream()
-                .map(MissionConverter::toStoreMissionPreviewDTO) // Misson을 StoreMissionPreviewDTO로 변환
+                .map(MissionConverter::toStoreMissionPreviewDTO) // Mission을 StoreMissionPreviewDTO로 변환
                 .toList();
 
         return MissionResponse.StoreMissionPreViewListDTO.builder()
@@ -63,6 +63,35 @@ public class MissionConverter {
                 .isFirst(storeMissionPage.isFirst())
                 .isLast(storeMissionPage.isLast())
                 .storeName(storeName)
+                .build();
+    }
+
+    // 멤버 미션 조회 관련 컨버터
+    public static MissionResponse.MemberMissionPreviewDTO toMemberMissionPreviewDTO(MemberMission memberMission) {
+        return MissionResponse.MemberMissionPreviewDTO.builder()
+                .missionStatus(memberMission.getStatus().name()) // 미션 상태
+                .storeName(memberMission.getMission().getStore().getStoreName())
+                .content(memberMission.getMission().getMissionContent()) // 미션 내용
+                .money(memberMission.getMission().getMissionMoney())     // 기준 금액
+                .point(memberMission.getMission().getMissionPoint())     // 적립 포인트
+                .createdAt(memberMission.getCreatedAt())    // 생성일자
+                .build();
+    }
+
+    // 멤버 미션 목록 조회 관련 컨버터
+    public static MissionResponse.MemberMissionPreViewListDTO toMemberMissionPreViewListDTO(Page<MemberMission> memberMissionPage){
+        // MemberMissionList 리스트를 MemberMissionPreviewDTO로 변환
+        List<MissionResponse.MemberMissionPreviewDTO> memberMissionList = memberMissionPage.stream()
+                .map(MissionConverter::toMemberMissionPreviewDTO) // Mission을 MemberMissionPreviewDTO로 변환
+                .toList();
+
+        return MissionResponse.MemberMissionPreViewListDTO.builder()
+                .missionList(memberMissionList)
+                .listSize(memberMissionList.size())
+                .totalPage(memberMissionPage.getTotalPages())
+                .totalElements(memberMissionPage.getTotalElements())
+                .isFirst(memberMissionPage.isFirst())
+                .isLast(memberMissionPage.isLast())
                 .build();
     }
 }

--- a/src/main/java/com/umc/workbook/repository/MemberMissionRepository/MemberMissionRepository.java
+++ b/src/main/java/com/umc/workbook/repository/MemberMissionRepository/MemberMissionRepository.java
@@ -1,6 +1,8 @@
 package com.umc.workbook.repository.MemberMissionRepository;
 
+import com.umc.workbook.domain.Member;
 import com.umc.workbook.domain.Mission;
+import com.umc.workbook.domain.enums.MissionStatus;
 import com.umc.workbook.domain.mapping.MemberMission;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,5 +15,7 @@ import java.util.Optional;
 @Repository
 public interface MemberMissionRepository extends JpaRepository<MemberMission, Long> {
     Optional<MemberMission> findMemberMissionByMissionIdAndMemberId(Long missionId, Long memberId);
-//    Page<MemberMission> findByMissionIn(List<Mission> missions, Pageable pageable);
+    
+    // 멤버, 미션 상태와 일치하는 멤버-미션을 페이지로 반환
+    Page<MemberMission> findAllMemberMissionsByMemberAndStatus(Member member, MissionStatus status, Pageable pageable);
 }

--- a/src/main/java/com/umc/workbook/repository/MissionRepository/MissionRepository.java
+++ b/src/main/java/com/umc/workbook/repository/MissionRepository/MissionRepository.java
@@ -6,5 +6,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MissionRepository extends JpaRepository<Mission, Long>, MissionRepositoryCustom {
+    // 가게 아이디와 일치하는 모든 미션을 페이지로 반환
     Page<Mission> findAllMissionByStoreId(Long storeId, Pageable pageable);
 }

--- a/src/main/java/com/umc/workbook/service/MissionService/MissionQueryService.java
+++ b/src/main/java/com/umc/workbook/service/MissionService/MissionQueryService.java
@@ -16,4 +16,7 @@ public interface MissionQueryService {
 
     // 가게의 미션 목록 조회 (페이지네이션 적용)
     MissionResponse.StoreMissionPreViewListDTO getStoreMissionPage(Long storeId, Integer page);
+
+    // 멤버의 미션 상태에 따른 목록 조회 (페이지네이션 적용)
+    MissionResponse.MemberMissionPreViewListDTO getMemberMissionPage(Long memberId, String status, Integer page);
 }

--- a/src/main/java/com/umc/workbook/service/MissionService/MissionQueryServiceImpl.java
+++ b/src/main/java/com/umc/workbook/service/MissionService/MissionQueryServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MissionQueryServiceImpl implements MissionQueryService {
+    private final MemberMissionRepository memberMissionRepository;
     private final MissionRepository missionRepository;
     private final MemberRepository memberRepository;
     private final StoreRepository storeRepository;
@@ -72,8 +73,20 @@ public class MissionQueryServiceImpl implements MissionQueryService {
     @Override
     public MissionResponse.StoreMissionPreViewListDTO getStoreMissionPage(Long storeId, Integer page) {
         Store store = storeRepository.findById(storeId).get();
+
+        // 가게 아이디와 일치하는 미션 페이지 조회
         Page<Mission> storeMissionPage = missionRepository.findAllMissionByStoreId(storeId, pageRequest(page));
 
         return MissionConverter.toStoreMissionPreViewListDTO(storeMissionPage, store.getStoreName());
+    }
+
+    // 멤버의 미션 상태에 따른 미션 목록 조회 (페이지네이션 적용)
+    @Override
+    public MissionResponse.MemberMissionPreViewListDTO getMemberMissionPage(Long memberId, String status, Integer page) {
+        Member member = memberRepository.findById(memberId).get();
+        // 멤버, 미션 상태와 일치하는 멤버-미션 페이지 조회
+        Page<MemberMission> memberMissionPage = memberMissionRepository.findAllMemberMissionsByMemberAndStatus(member, MissionStatus.valueOf(status.toUpperCase()), pageRequest(page));
+
+        return MissionConverter.toMemberMissionPreViewListDTO(memberMissionPage);
     }
 }


### PR DESCRIPTION
## 변경 사항
- 페이지네이션을 활용하여 memberId에 해당하는 멤버의 미션 목록을 미션 상태인 status(challenging, complete)와 페이지 번호에 따라 조회할 수 있는 API 구현
- API 경로명이 겹치는 문제를 해결하기 위해 가게의 미션 목록 조회 API 경로명을 
/api/mission?storeId={storeId}&page={page}  ->  /api/mission/store?storeId={storeId}&page={page} 로 변경
- 커밋 메시지에 이슈 번호  잘못 기재 15 -> #17 
