### PR TITLE
[Feat] 진행 중인 미션 진행 완료로 바꾸기 API 구현

### DIFF
--- a/src/main/java/com/umc/workbook/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/workbook/apiPayload/code/status/ErrorStatus.java
@@ -40,6 +40,8 @@ public enum ErrorStatus implements BaseErrorCode {
     MISSION_NOT_FOUND(HttpStatus.BAD_REQUEST, "MISSION4001", "존재하지 않는 미션입니다."),
     MISSION_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "MISSION4002", "이미 도전 중 혹은 완료한 미션입니다."),
     MISSION_STATUS_NOT_FOUND(HttpStatus.BAD_REQUEST, "MISSION4003", "존재하지 않는 미션 상태입니다."),
+    MISSION_ALREADY_COMPLETE(HttpStatus.BAD_REQUEST, "MISSION4004", "이미 도전 완료된 미션입니다."),
+    MISSION_NOT_EQUAL_MEMBER(HttpStatus.BAD_REQUEST, "MISSION4005", "멤버의 미션이 아닙니다."),
 
     // 페이지 번호
     PAGE_NOT_FOUND(HttpStatus.BAD_REQUEST, "PAGE4001", "페이지 번호는 1 이상이어야 합니다.");

--- a/src/main/java/com/umc/workbook/controller/MissionController.java
+++ b/src/main/java/com/umc/workbook/controller/MissionController.java
@@ -2,6 +2,8 @@ package com.umc.workbook.controller;
 
 import com.umc.workbook.apiPayload.ApiResponse;
 import com.umc.workbook.domain.enums.MissionStatus;
+import com.umc.workbook.domain.mapping.MemberMission;
+import com.umc.workbook.dto.member.MemberResponse;
 import com.umc.workbook.dto.mission.MissionDto;
 import com.umc.workbook.dto.mission.MissionRequest;
 import com.umc.workbook.dto.mission.MissionResponse;
@@ -63,34 +65,6 @@ public class MissionController {
     }
 
 
-    // 멤버별 진행중인 미션 불러오기
-    // localhost:8080/api/mission/challenging?memberId={memberId}&pageNumber={pageNumber}
-    @GetMapping("/challenging")
-    public ResponseEntity<?> getChallengingMissionPage(@RequestParam(name="memberId") Long memberId,
-                                                    @RequestParam(name="pageNumber") Integer pageNumber) throws Exception {
-        try {
-            Page<MissionDto.StatusResponse> challenginMissionPage = missionQueryService.pagedMissionsByMemberIdAndMissionStatus(memberId, MissionStatus.CHALLENGING, pageNumber);
-            return ResponseEntity.ok(challenginMissionPage);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(e.getMessage());
-        }
-    }
-
-    // 멤버별 진행완료된 미션 불러오기
-    // localhost:8080/api/mission/complete?memberId={memberId}&pageNumber={pageNumber}
-    @GetMapping("/complete")
-    public ResponseEntity<?> getCompleteMissionPage(@RequestParam(name="memberId") Long memberId,
-                                                       @RequestParam(name="pageNumber") Integer pageNumber) throws Exception {
-        try {
-            Page<MissionDto.StatusResponse> completeMissionPage = missionQueryService.pagedMissionsByMemberIdAndMissionStatus(memberId, MissionStatus.COMPLETE, pageNumber);
-            return ResponseEntity.ok(completeMissionPage);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                    .body(e.getMessage());
-        }
-    }
-
     // 특정 가게의 미션 목록 조회
     @GetMapping("/store")
     @Operation(summary = "특정 가게의 미션 목록 조회 API", description = "가게의 모든 미션 목록을 조회하는 API이며, 페이징을 포함합니다. query String 으로 page 번호를 주세요")
@@ -132,4 +106,55 @@ public class MissionController {
 
         return ApiResponse.onSuccess(response);
     }
+
+    // 멤버의 진행중인 미션을 진행완료로 변경
+    @PatchMapping("/member")
+    @Operation(summary = "멤버의 진행중인 미션을 진행완료로 변경하는 API", description = "멤버의 진행중인 미션을 진행완료로 변경하는 API 입니다. 해당 미션이 이미 진행완료된 경우, 변경이 불가능합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200",description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "access 토큰 만료",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "access 토큰 모양이 이상함",content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+    })
+    @Parameters({
+            @Parameter(name = "memberId", description = "멤버의 아이디, query parameter 입니다."),
+            @Parameter(name = "missionId", description = "상태를 변경할 미션 아이디, query parameter 입니다.")
+    })
+    ApiResponse<MissionResponse.UpdateMissionStatusDTO> updateMemberMissionStatus (@RequestParam(name = "memberId") @ExistMember Long memberId,
+                                              @RequestParam(name = "missionId") Long missionId){
+
+        MissionResponse.UpdateMissionStatusDTO response = missionCommandService.setMemberMissionStatus(memberId, missionId);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+
+//    // 멤버별 진행중인 미션 불러오기
+//    // localhost:8080/api/mission/challenging?memberId={memberId}&pageNumber={pageNumber}
+//    @GetMapping("/challenging")
+//    public ResponseEntity<?> getChallengingMissionPage(@RequestParam(name="memberId") Long memberId,
+//                                                    @RequestParam(name="pageNumber") Integer pageNumber) throws Exception {
+//        try {
+//            Page<MissionDto.StatusResponse> challenginMissionPage = missionQueryService.pagedMissionsByMemberIdAndMissionStatus(memberId, MissionStatus.CHALLENGING, pageNumber);
+//            return ResponseEntity.ok(challenginMissionPage);
+//        } catch (IllegalArgumentException e) {
+//            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+//                    .body(e.getMessage());
+//        }
+//    }
+//
+//    // 멤버별 진행완료된 미션 불러오기
+//    // localhost:8080/api/mission/complete?memberId={memberId}&pageNumber={pageNumber}
+//    @GetMapping("/complete")
+//    public ResponseEntity<?> getCompleteMissionPage(@RequestParam(name="memberId") Long memberId,
+//                                                       @RequestParam(name="pageNumber") Integer pageNumber) throws Exception {
+//        try {
+//            Page<MissionDto.StatusResponse> completeMissionPage = missionQueryService.pagedMissionsByMemberIdAndMissionStatus(memberId, MissionStatus.COMPLETE, pageNumber);
+//            return ResponseEntity.ok(completeMissionPage);
+//        } catch (IllegalArgumentException e) {
+//            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+//                    .body(e.getMessage());
+//        }
+//    }
+
 }

--- a/src/main/java/com/umc/workbook/converter/MissionConverter.java
+++ b/src/main/java/com/umc/workbook/converter/MissionConverter.java
@@ -95,4 +95,11 @@ public class MissionConverter {
                 .isLast(memberMissionPage.isLast())
                 .build();
     }
+
+    // 미션 상태를 도전완료로 변경 컨버터
+    public static MissionResponse.UpdateMissionStatusDTO toUpdateMissionStatusDTO(MemberMission memberMission){
+        return MissionResponse.UpdateMissionStatusDTO.builder()
+                .missionStatus(memberMission.getStatus().name())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/workbook/dto/mission/MissionResponse.java
+++ b/src/main/java/com/umc/workbook/dto/mission/MissionResponse.java
@@ -81,4 +81,12 @@ public class MissionResponse {
         String missionStatus; // 미션 상태
         String storeName; // 가게 이름
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateMissionStatusDTO { // 미션 상태를 도전완료로 변경
+        String missionStatus; // 변경된 미션 상태
+    }
 }

--- a/src/main/java/com/umc/workbook/service/MissionService/MissionCommandService.java
+++ b/src/main/java/com/umc/workbook/service/MissionService/MissionCommandService.java
@@ -9,4 +9,7 @@ public interface MissionCommandService {
 
     // 미션을 도전중인 미션에 추가 (멤버-미션 테이블 생성)
     MissionResponse.CreateMemberMissionResultDTO addMemberMission(Long missionId, Long memberId);
+
+    // 진행중인 미션을 완료로 변경
+    MissionResponse.UpdateMissionStatusDTO setMemberMissionStatus(Long memberId, Long memberMissionId);
 }


### PR DESCRIPTION
## 변경 사항
- 멤버의 진행 중인 미션을 진행 완료로 바꾸기 API 구현
- `GeneralException` 을 상속 받은 커스텀 핸들러 `MissionHandler` 를 통해 
  - 존재하지 않는 MemberMission일 경우 에러 반환
  - 멤버의 MemberMission이 아닐 경우 에러 반환
  - 이미 도전중인 MemberMission일 경우 에러 반환
